### PR TITLE
chore(crawler): configure Ruff linter and formatter

### DIFF
--- a/apps/crawler/pyproject.toml
+++ b/apps/crawler/pyproject.toml
@@ -34,7 +34,7 @@ target-version = "py313"
 line-length = 88
 
 [tool.ruff.lint]
-# Modern Python best practices rule set
+# Modern Python best practices rule set with web scraping focus
 select = [
     "E",   # pycodestyle errors
     "W",   # pycodestyle warnings  
@@ -42,11 +42,16 @@ select = [
     "I",   # isort (import sorting)
     "N",   # pep8-naming
     "UP",  # pyupgrade (modern Python syntax)
-    "B",   # flake8-bugbear (bug detection)
-    "S",   # bandit (security)
+    "B",   # flake8-bugbear - catches subtle bugs
+    "S",   # bandit (security) - critical for web scraping
     "C4",  # flake8-comprehensions
     "PIE", # flake8-pie (unnecessary code)
     "RUF", # Ruff-specific rules
+    # Enhanced security and web scraping specific rules
+    "A",   # flake8-builtins (avoid shadowing builtins)
+    "T20", # flake8-print (no print statements in production)
+    "DTZ", # flake8-datetimez (proper timezone handling)
+    "SLF", # flake8-self (proper self usage in classes)
 ]
 
 # Common ignores for practical development
@@ -54,6 +59,7 @@ ignore = [
     "S101",  # Use of assert (common in tests)
     "S603",  # subprocess call without shell=True check
     "S607",  # Starting a process with a partial executable path
+    "T201",  # Allow print() in CLI applications and debugging
 ]
 
 [tool.ruff.format]

--- a/apps/crawler/pyproject.toml
+++ b/apps/crawler/pyproject.toml
@@ -48,10 +48,11 @@ select = [
     "PIE", # flake8-pie (unnecessary code)
     "RUF", # Ruff-specific rules
     # Enhanced security and web scraping specific rules
-    "A",   # flake8-builtins (avoid shadowing builtins)
-    "T20", # flake8-print (no print statements in production)
-    "DTZ", # flake8-datetimez (proper timezone handling)
-    "SLF", # flake8-self (proper self usage in classes)
+    "A",    # flake8-builtins (avoid shadowing builtins)
+    "T20",  # flake8-print (no print statements in production)
+    "DTZ",  # flake8-datetimez (proper timezone handling)
+    "SLF",  # flake8-self (proper self usage in classes)
+    "PERF", # perflint - performance anti-patterns for web scraping
 ]
 
 # Common ignores for practical development

--- a/apps/crawler/pyproject.toml
+++ b/apps/crawler/pyproject.toml
@@ -28,3 +28,43 @@ dev = [
     "ruff>=0.12.8",
     "lxml-stubs>=0.5.1",
 ]
+
+[tool.ruff]
+target-version = "py313"
+line-length = 88
+
+[tool.ruff.lint]
+# Modern Python best practices rule set
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings  
+    "F",   # Pyflakes
+    "I",   # isort (import sorting)
+    "N",   # pep8-naming
+    "UP",  # pyupgrade (modern Python syntax)
+    "B",   # flake8-bugbear (bug detection)
+    "S",   # bandit (security)
+    "C4",  # flake8-comprehensions
+    "PIE", # flake8-pie (unnecessary code)
+    "RUF", # Ruff-specific rules
+]
+
+# Common ignores for practical development
+ignore = [
+    "S101",  # Use of assert (common in tests)
+    "S603",  # subprocess call without shell=True check
+    "S607",  # Starting a process with a partial executable path
+]
+
+[tool.ruff.format]
+# Black-compatible formatting
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+[tool.ruff.lint.isort]
+# Import sorting configuration
+known-first-party = ["fuelog_crawler"]
+force-single-line = false
+combine-as-imports = true


### PR DESCRIPTION
## Context
- Adds Ruff linter and formatter to enforce code quality and maintain consistency in the project.
- Focus on modern Python best practices and secure coding with selected rule sets.

## Changes
- Configures Ruff with pycodestyle, Pyflakes, isort, and other rule sets for linting.
- Sets Black-compatible formatting options including quote style and line ending.
- Specifies custom import sorting for first-party modules.

## Testing
- Ensure code meets configured Ruff rules through automated linting tasks.
- Verify compatibility with existing CI/CD scripts and development workflows.

## Breaking Changes
- None

## Links
- Refs feature branch 'feature/git_hooks_setup'